### PR TITLE
feat: Redesign music player UI to match screenshot

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,51 +14,21 @@
     <script src="https://cdn.jsdelivr.net/npm/jsmediatags@3.9.7/dist/jsmediatags.min.js"></script>
     <style>
         :root {
-            /* Custom colors based on user request */
-            --background-color: #18737F;
-            --on-background-color: #FFFFFF;
-            --surface-color: #2091A0;
-            --on-surface-color: #FFFFFF;
-            --card-color: #29A9BA;
-            --on-card-color: #FFFFFF;
-            --primary-color: #B2D1D4;
-            --on-primary-color: #18737F;
-            --primary-container: #5D959C;
-            --on-primary-container: #FFFFFF;
-            --secondary-container: #4D7A82;
-            --on-secondary-container: #FFFFFF;
+            --background-color: #0B111E;
+            --surface-color: #161E2C;
+            --on-surface-color: #F9FAFB;
+            --primary-accent: #0891B2; /* cyan-600 */
+            --primary-accent-darker: #0E7490; /* cyan-700 */
+            --secondary-text: #9CA3AF; /* gray-400 */
+            --card-background: #1F2937;
         }
+
         body {
             font-family: 'Inter', sans-serif;
             background-color: var(--background-color);
-            color: var(--on-background-color);
-        }
-        .music-player {
-            background-color: var(--surface-color);
             color: var(--on-surface-color);
         }
-        .controls button, .add-files-btn, .fab-menu-btn {
-            background-color: var(--primary-container);
-            color: var(--on-primary-container);
-            transition: transform 0.1s ease-in-out;
-        }
-        .controls button:active, .add-files-btn:active, .fab-menu-btn:active {
-            transform: scale(0.95);
-        }
-        .progress-bar-container {
-            background-color: var(--secondary-container);
-            cursor: pointer;
-        }
-        .progress-bar {
-            background-color: var(--primary-color);
-        }
-        .playlist-item {
-            transition: background-color 0.1s ease-in-out;
-        }
-        .playlist-item.active {
-            background-color: var(--secondary-container);
-            font-weight: 600;
-        }
+
         /* Custom scrollbar for a more integrated feel */
         .playlist::-webkit-scrollbar {
             width: 8px;
@@ -68,111 +38,101 @@
             border-radius: 10px;
         }
         .playlist::-webkit-scrollbar-thumb {
-            background-color: var(--primary-container);
+            background-color: var(--primary-accent);
             border-radius: 10px;
             border: 2px solid var(--surface-color);
         }
-        .add-files-btn {
-            background-color: var(--secondary-container);
-            color: var(--on-secondary-container);
-        }
-        .fab-menu {
-            position: fixed;
-            bottom: 70px;
-            right: 20px;
-            z-index: 50;
-        }
-        .fab-menu-list {
-            position: absolute;
-            bottom: calc(100% + 10px);
-            right: 0;
-            background-color: var(--surface-color);
-            border-radius: 1.5rem;
-            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-            transform-origin: bottom right;
-            transition: transform 0.2s ease-out, opacity 0.2s ease-out;
-        }
-        .fab-menu-list.hidden {
-            transform: scale(0.5);
-            opacity: 0;
-            pointer-events: none;
-        }
-        .fab-menu-list button {
-            color: var(--on-surface-color);
-            transition: background-color 0.1s ease;
-        }
-        .fab-menu-list button:hover {
-            background-color: var(--secondary-container);
-        }
     </style>
 </head>
-<body class="flex items-center justify-center min-h-screen p-4 md:p-8">
+<body class="flex items-center justify-center">
 
-    <div id="player-container" class="music-player max-w-sm w-full p-6 rounded-3xl shadow-lg flex flex-col items-center">
+    <div class="max-w-sm w-full h-screen flex flex-col bg-background-color">
 
-        <!-- Album Art and Song Info -->
-        <div class="w-full flex flex-col items-center mb-6">
-            <img id="album-art" src="https://i.supaimg.com/ee72c44a-264d-446c-8b64-1d677795ce3c.jpg" alt="Album Art"
-                 class="w-64 h-64 rounded-3xl shadow-lg object-cover mb-4">
-            <h2 id="song-title" class="text-xl font-semibold text-center mb-1">Song Title</h2>
-            <p id="artist-name" class="text-sm text-gray-200 text-center">Artist Name</p>
-            <p id="album-name" class="text-xs text-gray-300 text-center hidden"></p>
-        </div>
-
-        <!-- Progress Bar -->
-        <div id="progress-bar-container" class="progress-bar-container w-full h-2.5 rounded-full mb-6">
-            <div id="progress-bar" class="progress-bar h-2.5 rounded-full" style="width: 0%;"></div>
-        </div>
-
-        <!-- Controls -->
-        <div class="controls flex items-center justify-center space-x-4 mb-8">
-            <button id="prev-btn" class="p-4 rounded-full shadow-lg">
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M19 19L19 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                    <path d="M15 17L9 12L15 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
+        <!-- Header -->
+        <header class="p-6 flex justify-between items-center">
+            <h1 class="text-4xl font-bold text-white">Library</h1>
+            <button class="text-white">
+                <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-settings"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 0 2l-.15.08a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.1a2 2 0 0 1 0-2l.15-.08a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
             </button>
-            <button id="play-pause-btn" class="p-6 rounded-full shadow-lg">
-                <svg id="play-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-8 h-8">
-                    <path d="M5 3L19 12L5 21V3Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-                <svg id="pause-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 hidden">
-                    <path d="M6 5L6 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                    <path d="M18 5L18 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-            </button>
-            <button id="next-btn" class="p-4 rounded-full shadow-lg">
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M5 5L5 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                    <path d="M9 7L15 12L9 17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </svg>
-            </button>
+        </header>
+
+        <!-- Tabs -->
+        <div class="px-6 mb-4">
+            <div class="flex space-x-2">
+                <button class="flex-1 py-2 px-4 rounded-full text-sm font-semibold bg-primary-accent text-white">SONGS</button>
+                <button class="flex-1 py-2 px-4 rounded-full text-sm font-semibold bg-card-background text-white">ALBUMS</button>
+                <button class="flex-1 py-2 px-4 rounded-full text-sm font-semibold bg-card-background text-white">ARTIST</button>
+                <button class="flex-1 py-2 px-4 rounded-full text-sm font-semibold bg-card-background text-white">PLAYLISTS</button>
+            </div>
         </div>
 
-        <!-- Playlist -->
-        <div id="playlist" class="w-full max-h-64 overflow-y-auto mt-4 px-2">
-            <!-- Playlist items will be injected here by JavaScript -->
+        <!-- Main Content -->
+        <main class="relative flex-1 overflow-y-auto px-6 space-y-4 bg-surface-color rounded-t-3xl">
+            <div class="pt-6 flex items-center justify-between">
+                <button id="shuffle-btn" class="flex items-center space-x-2 bg-primary-accent-darker text-white py-2 px-5 rounded-full font-semibold">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-shuffle"><path d="M2 18h1.4c1.3 0 2.5-.6 3.3-1.7l6.1-8.6c.7-1.1 2-1.7 3.3-1.7H22"/><path d="m18 2 4 4-4 4"/><path d="M2 6h1.4c1.3 0 2.5.6 3.3 1.7l2.1 3 2.1 3c.7 1.1 2 1.7 3.3 1.7H22"/><path d="m18 22 4-4-4-4"/></svg>
+                    <span>Shuffle</span>
+                </button>
+                <button id="sort-btn" class="text-white p-2 rounded-full bg-card-background">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" x2="21" y1="12" y2="12"/><line x1="3" x2="21" y1="6" y2="6"/><line x1="3" x2="21" y1="18" y2="18"/></svg>
+                </button>
+            </div>
+
+            <!-- Sort Menu -->
+            <div id="sort-menu" class="absolute right-6 top-16 bg-card-background p-2 rounded-lg shadow-lg space-y-1 hidden">
+                <button id="sort-by-album" class="w-full text-left px-4 py-2 text-sm hover:bg-surface-color rounded">Sort by Album</button>
+                <button id="sort-by-artist" class="w-full text-left px-4 py-2 text-sm hover:bg-surface-color rounded">Sort by Artist</button>
+            </div>
+
+            <!-- Playlist -->
+            <div id="playlist" class="playlist space-y-2 pb-24">
+                <!-- Playlist items will be injected here by JavaScript -->
+            </div>
+        </main>
+
+        <!-- Now Playing Bar -->
+        <div id="now-playing-bar" class="fixed bottom-20 left-0 right-0 max-w-sm mx-auto p-3 bg-card-background/90 backdrop-blur-sm rounded-xl hidden">
+            <div id="progress-bar-container" class="w-full h-1 bg-gray-600 rounded-full cursor-pointer mb-2">
+                <div id="progress-bar" class="h-1 bg-primary-accent rounded-full" style="width: 0%;"></div>
+            </div>
+            <div class="flex items-center space-x-4">
+                <img id="now-playing-art" src="" alt="Album Art" class="w-10 h-10 rounded-md">
+                <div class="flex-1 overflow-hidden">
+                    <p id="now-playing-title" class="text-sm font-semibold text-on-surface-color truncate">Song Title</p>
+                    <p id="now-playing-artist" class="text-xs text-secondary-text truncate">Artist</p>
+                </div>
+                <div class="flex items-center space-x-2">
+                    <button id="prev-btn">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-step-back"><line x1="18" x2="18" y1="20" y2="4"/><polygon points="14,20 4,12 14,4"/></svg>
+                    </button>
+                    <button id="play-pause-btn">
+                        <svg id="play-icon" xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-play-circle"><circle cx="12" cy="12" r="10"/><polygon points="10 8 16 12 10 16 10 8"/></svg>
+                        <svg id="pause-icon" xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-pause-circle hidden"><circle cx="12" cy="12" r="10"/><line x1="10" x2="10" y1="15" y2="9"/><line x1="14" x2="14" y1="15" y2="9"/></svg>
+                    </button>
+                    <button id="next-btn">
+                         <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-step-forward"><line x1="6" x2="6" y1="4" y2="20"/><polygon points="10,4 20,12 10,20"/></svg>
+                    </button>
+                </div>
+            </div>
         </div>
 
-    </div>
-
-    <!-- Floating Action Button (FAB) Menu -->
-    <div class="fab-menu">
-        <div id="fab-menu-list" class="fab-menu-list p-2 space-y-2 hidden">
-            <button id="add-files-btn" class="w-full px-6 py-3 rounded-full text-left font-medium">Browse</button>
-            <button id="sort-by-album" class="w-full px-6 py-3 rounded-full text-left font-medium">Album</button>
-            <button id="sort-by-artist" class="w-full px-6 py-3 rounded-full text-left font-medium">Artist</button>
-        </div>
-        <button id="fab-menu-btn" class="fab-menu-btn w-14 h-14 rounded-full flex items-center justify-center shadow-lg">
-            <svg id="folder-open-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 hidden">
-                <path d="M3 21H21V7H12L10 5H3V21Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-            <svg id="folder-closed-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-6 h-6">
-                <path d="M3 17L3 7L8.98182 7C9.53589 7 10.068 6.77661 10.4571 6.38605L11.5316 5.31751C11.9207 4.92695 12.4528 4.70356 13.0069 4.70356H21V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                <path d="M3 17L3 19C3 20.1046 3.89543 21 5 21H21C22.1046 21 23 20.1046 23 19V17H3Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                <path d="M3 17H21" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-        </button>
+        <!-- Bottom Navigation -->
+        <nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto p-4 bg-card-background/80 backdrop-blur-sm">
+            <div class="flex justify-around items-center">
+                <button class="flex flex-col items-center space-y-1 text-secondary-text">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+                    <span class="text-xs">Home</span>
+                </button>
+                <button class="flex flex-col items-center space-y-1 text-secondary-text">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+                    <span class="text-xs">Search</span>
+                </button>
+                <button class="flex flex-col items-center space-y-1 text-primary-accent">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
+                    <span class="text-xs font-bold">Library</span>
+                </button>
+            </div>
+        </nav>
     </div>
     <input type="file" id="file-input" class="hidden" multiple accept="audio/*">
 
@@ -183,35 +143,35 @@
 
             // DOM Elements
             const audio = new Audio();
-            const songTitle = document.getElementById('song-title');
-            const artistName = document.getElementById('artist-name');
-            const albumName = document.getElementById('album-name');
-            const albumArt = document.getElementById('album-art');
-            const playPauseBtn = document.getElementById('play-pause-btn');
-            const prevBtn = document.getElementById('prev-btn');
-            const nextBtn = document.getElementById('next-btn');
+            const playlistElement = document.getElementById('playlist');
+            const shuffleBtn = document.getElementById('shuffle-btn');
+            const fileInput = document.getElementById('file-input');
+            const nowPlayingBar = document.getElementById('now-playing-bar');
             const progressBar = document.getElementById('progress-bar');
             const progressBarContainer = document.getElementById('progress-bar-container');
+            const nowPlayingArt = document.getElementById('now-playing-art');
+            const nowPlayingTitle = document.getElementById('now-playing-title');
+            const nowPlayingArtist = document.getElementById('now-playing-artist');
+            const prevBtn = document.getElementById('prev-btn');
+            const playPauseBtn = document.getElementById('play-pause-btn');
+            const nextBtn = document.getElementById('next-btn');
             const playIcon = document.getElementById('play-icon');
             const pauseIcon = document.getElementById('pause-icon');
-            const playlistElement = document.getElementById('playlist');
-            const addFilesBtn = document.getElementById('add-files-btn');
-            const fileInput = document.getElementById('file-input');
-            const fabMenuBtn = document.getElementById('fab-menu-btn');
-            const fabMenuList = document.getElementById('fab-menu-list');
-            const folderOpenIcon = document.getElementById('folder-open-icon');
-            const folderClosedIcon = document.getElementById('folder-closed-icon');
+            const sortBtn = document.getElementById('sort-btn');
+            const sortMenu = document.getElementById('sort-menu');
             const sortByAlbumBtn = document.getElementById('sort-by-album');
             const sortByArtistBtn = document.getElementById('sort-by-artist');
 
             // Player State
+            let songs = [];
             let currentSongIndex = 0;
             let isPlaying = false;
 
             // Helper function to convert album art from tags to a data URL
             function getAlbumArtURL(picture) {
                 if (!picture || !picture.data || !picture.format) {
-                    return 'https://i.supaimg.com/ee72c44a-264d-446c-8b64-1d677795ce3c.jpg';
+                    // A default placeholder image
+                    return 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLW11c2ljIj48cGF0aCBkPSJNOSAxOHYtNVMyMSAyIDEyIDJ2MTMiLz48Y2lyY2xlIGN4PSI2IiBjeT0iMTgiIHI9IjMiLz48Y2lyY2xlIGN4PSIxOCIgY3k9IjE2IiByPSIzIi8+PC9zdmc+';
                 }
                 const base64String = btoa(String.fromCharCode.apply(null, picture.data));
                 return `data:${picture.format};base64,${base64String}`;
@@ -221,13 +181,13 @@
             function loadSong(songIndex) {
                 if (songIndex >= 0 && songIndex < songs.length) {
                     const song = songs[songIndex];
-                    songTitle.textContent = song.title;
-                    artistName.textContent = song.artist;
-                    albumName.textContent = song.album;
-                    albumArt.src = song.albumArt;
                     audio.src = song.src;
+                    nowPlayingArt.src = song.albumArt;
+                    nowPlayingTitle.textContent = song.title;
+                    nowPlayingArtist.textContent = song.artist;
                     currentSongIndex = songIndex;
                     updatePlaylistUI();
+                    nowPlayingBar.classList.remove('hidden');
                 }
             }
 
@@ -244,6 +204,7 @@
                     pauseIcon.classList.remove('hidden');
                 }
                 isPlaying = !isPlaying;
+                updatePlaylistUI();
             }
 
             // Function to play the next song
@@ -251,12 +212,10 @@
                 if (songs.length === 0) return;
                 const nextIndex = (currentSongIndex + 1) % songs.length;
                 loadSong(nextIndex);
-                if (!isPlaying) {
-                    isPlaying = true;
-                    playIcon.classList.add('hidden');
-                    pauseIcon.classList.remove('hidden');
-                }
                 audio.play();
+                isPlaying = true;
+                playIcon.classList.add('hidden');
+                pauseIcon.classList.remove('hidden');
             }
 
             // Function to play the previous song
@@ -264,12 +223,10 @@
                 if (songs.length === 0) return;
                 const prevIndex = (currentSongIndex - 1 + songs.length) % songs.length;
                 loadSong(prevIndex);
-                if (!isPlaying) {
-                    isPlaying = true;
-                    playIcon.classList.add('hidden');
-                    pauseIcon.classList.remove('hidden');
-                }
                 audio.play();
+                isPlaying = true;
+                playIcon.classList.add('hidden');
+                pauseIcon.classList.remove('hidden');
             }
 
             // Update the progress bar as the song plays
@@ -293,41 +250,84 @@
             // Generate the playlist UI based on the current songs array
             function renderPlaylist() {
                 playlistElement.innerHTML = '';
+                if (songs.length === 0) {
+                    playlistElement.innerHTML = `<p class="text-center text-secondary-text mt-8">Click Shuffle to add songs.</p>`;
+                    return;
+                }
                 songs.forEach((song, index) => {
                     const item = document.createElement('div');
-                    item.classList.add('playlist-item', 'p-4', 'rounded-xl', 'cursor-pointer', 'flex', 'items-center', 'space-x-4');
+                    item.className = 'flex items-center p-3 rounded-lg cursor-pointer bg-card-background space-x-4';
+
+                    const playingClass = (index === currentSongIndex) ? 'border-2 border-primary-accent' : '';
+                    const textColor = (index === currentSongIndex) ? 'text-primary-accent' : 'text-on-surface-color';
+
                     item.innerHTML = `
-                        <img src="${song.albumArt}" alt="${song.title} album art" class="w-10 h-10 rounded-lg object-cover">
-                        <div class="flex-1">
-                            <h3 class="text-sm font-semibold">${song.title}</h3>
-                            <p class="text-xs text-gray-500">${song.artist}</p>
-                            <p class="text-xs text-gray-400">${song.album}</p>
+                        <img src="${song.albumArt}" alt="${song.title} album art" class="w-12 h-12 rounded-md object-cover ${playingClass}">
+                        <div class="flex-1 overflow-hidden">
+                            <h3 class="text-base font-semibold truncate ${textColor}">${song.title}</h3>
+                            <p class="text-sm text-secondary-text truncate">${song.artist}</p>
                         </div>
+                        <button class="text-secondary-text hover:text-white">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>
+                        </button>
                     `;
                     item.addEventListener('click', () => {
-                        loadSong(index);
-                        playPauseSong();
+                        // If it's the same song, toggle play/pause. Otherwise, load and play new song.
+                        if (index === currentSongIndex) {
+                            playPauseSong();
+                        } else {
+                            loadSong(index);
+                            audio.play();
+                            isPlaying = true;
+                        }
                     });
                     playlistElement.appendChild(item);
                 });
-                updatePlaylistUI();
             }
 
             // Update the UI to show which song is currently active
             function updatePlaylistUI() {
-                const playlistItems = document.querySelectorAll('.playlist-item');
+                const playlistItems = playlistElement.querySelectorAll('.flex.items-center');
                 playlistItems.forEach((item, index) => {
+                    const img = item.querySelector('img');
+                    const title = item.querySelector('h3');
                     if (index === currentSongIndex) {
-                        item.classList.add('active');
+                        img.classList.add('border-2', 'border-primary-accent');
+                        title.classList.add('text-primary-accent');
+                        title.classList.remove('text-on-surface-color');
                     } else {
-                        item.classList.remove('active');
+                        img.classList.remove('border-2', 'border-primary-accent');
+                        title.classList.remove('text-primary-accent');
+                        title.classList.add('text-on-surface-color');
                     }
                 });
             }
 
+            // Shuffle the current playlist
+            function shufflePlaylist() {
+                if (songs.length < 2) return;
+
+                // Standard Fisher-Yates shuffle algorithm
+                for (let i = songs.length - 1; i > 0; i--) {
+                    const j = Math.floor(Math.random() * (i + 1));
+                    [songs[i], songs[j]] = [songs[j], songs[i]];
+                }
+
+                // After shuffling, re-render the playlist and load the first song
+                currentSongIndex = 0;
+                isPlaying = false;
+                audio.pause();
+                renderPlaylist();
+                loadSong(0);
+            }
+
             // Logic for adding new files and reading metadata
-            addFilesBtn.addEventListener('click', () => {
-                fileInput.click();
+            shuffleBtn.addEventListener('click', () => {
+                if (songs.length > 0) {
+                    shufflePlaylist();
+                } else {
+                    fileInput.click();
+                }
             });
 
             fileInput.addEventListener('change', async (event) => {
@@ -360,7 +360,7 @@
                                 title: file.name.split('.').slice(0, -1).join('.'),
                                 artist: "Unknown Artist",
                                 album: "Unknown Album",
-                                albumArt: "https://i.supaimg.com/ee72c44a-264d-446c-8b64-1d677795ce3c.jpg",
+                                albumArt: getAlbumArtURL(null), // Use default art
                                 src: URL.createObjectURL(file)
                             });
                         }
@@ -369,35 +369,36 @@
                     if (newSongs.length > 0) {
                         songs.push(...newSongs);
                         renderPlaylist();
-                        loadSong(songs.length - newSongs.length);
-                        playPauseSong();
+                        // If this is the first batch of songs, load the first one and set a consistent initial state.
+                        if (songs.length === newSongs.length) {
+                             loadSong(0);
+                             isPlaying = false;
+                             playIcon.classList.remove('hidden');
+                             pauseIcon.classList.add('hidden');
+                        }
                     }
                 }
             });
 
-            // Logic for sorting and the floating menu
-            fabMenuBtn.addEventListener('click', (event) => {
-                event.stopPropagation();
-                const isHidden = fabMenuList.classList.toggle('hidden');
-                folderOpenIcon.classList.toggle('hidden', isHidden);
-                folderClosedIcon.classList.toggle('hidden', !isHidden);
-            });
+            // Player Event Listeners
+            prevBtn.addEventListener('click', prevSong);
+            playPauseBtn.addEventListener('click', playPauseSong);
+            nextBtn.addEventListener('click', nextSong);
+            audio.addEventListener('timeupdate', updateProgress);
+            audio.addEventListener('ended', nextSong);
+            progressBarContainer.addEventListener('click', seek);
 
-            document.addEventListener('click', (event) => {
-                if (!fabMenuList.contains(event.target) && !fabMenuBtn.contains(event.target)) {
-                    fabMenuList.classList.add('hidden');
-                    folderOpenIcon.classList.add('hidden');
-                    folderClosedIcon.classList.remove('hidden');
-                }
+            // Sort menu logic
+            sortBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                sortMenu.classList.toggle('hidden');
             });
 
             sortByAlbumBtn.addEventListener('click', () => {
                 if (songs.length > 0) {
                     songs.sort((a, b) => a.album.localeCompare(b.album));
                     renderPlaylist();
-                    fabMenuList.classList.add('hidden');
-                    folderOpenIcon.classList.add('hidden');
-                    folderClosedIcon.classList.remove('hidden');
+                    sortMenu.classList.add('hidden');
                 }
             });
 
@@ -405,27 +406,18 @@
                 if (songs.length > 0) {
                     songs.sort((a, b) => a.artist.localeCompare(b.artist));
                     renderPlaylist();
-                    fabMenuList.classList.add('hidden');
-                    folderOpenIcon.classList.add('hidden');
-                    folderClosedIcon.classList.remove('hidden');
+                    sortMenu.classList.add('hidden');
                 }
             });
 
-            // Player Event Listeners
-            playPauseBtn.addEventListener('click', playPauseSong);
-            nextBtn.addEventListener('click', nextSong);
-            prevBtn.addEventListener('click', prevSong);
-            audio.addEventListener('timeupdate', updateProgress);
-            audio.addEventListener('ended', nextSong);
-            progressBarContainer.addEventListener('click', seek);
+            // Hide sort menu if clicking outside
+            document.addEventListener('click', (e) => {
+                if (!sortMenu.contains(e.target) && !sortBtn.contains(e.target)) {
+                    sortMenu.classList.add('hidden');
+                }
+            });
 
             // Initial setup
-            if (songs.length > 0) {
-                loadSong(currentSongIndex);
-            } else {
-                songTitle.textContent = "No Songs";
-                artistName.textContent = "Add files to get started";
-            }
             renderPlaylist();
         });
     </script>


### PR DESCRIPTION
This commit completely overhauls the music player's user interface to align with the new design provided by the user.

- Replaced the old single-card layout with a modern, multi-section UI including a header, tabs, and a bottom navigation bar.
- Implemented a new dark-mode color scheme with cyan accents.
- Moved player controls (play/pause, next, previous, progress bar) to a floating "Now Playing" bar that appears when a song is selected.
- Re-implemented sorting functionality (by album and artist) in a new dropdown menu to restore a feature from the previous version.
- The "Shuffle" button now serves as the primary action for both shuffling the playlist and adding initial files.