### PR TITLE
feat: Add gradle wrapper and set version to 7.5

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https://services.gradle.org/distributions/gradle-7.5-bin.zip


### PR DESCRIPTION
The project was missing the gradle-wrapper.properties file, which caused issues with IDEs that require a specific Gradle version. This change adds the gradle-wrapper.properties file and sets the Gradle version to 7.5 to ensure compatibility.