### PR TITLE
feat: Upgrade Gradle and Android Gradle Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.4.2' apply false
-    id 'com.android.library' version '7.4.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
+    id 'com.android.application' version '8.13.0' apply false
+    id 'com.android.library' version '8.13.0' apply false
+    id 'org.jetbrains.kotlin.android' version '2.1.20' apply false
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
This commit addresses the project's incompatibility with the AIDE by upgrading the Gradle version and related build configurations.

The following changes were made:
- Created the `gradle/wrapper/gradle-wrapper.properties` file to manage the Gradle version.
- Set the Gradle distribution to version 8.14.2.
- Updated the Android Gradle Plugin to version 8.13.0 in the project-level `build.gradle` file.
- Updated the Kotlin plugin to version 2.1.20 to maintain compatibility with the new AGP version.