### PR TITLE
feat: Upgrade Gradle to 9.1 and AGP to 9.0.0-alpha05

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,10 @@ pluginManagement {
         mavenCentral()
     }
 }
+
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
This commit upgrades the project to Gradle 9.1 and Android Gradle Plugin 9.0.0-alpha05.

The following changes were made:
- Created `gradle/wrapper/gradle-wrapper.properties` and set the Gradle distribution to version 9.1.0.
- Manually added the `gradlew` and `gradlew.bat` scripts.
- Updated the Android Gradle Plugin to version 9.0.0-alpha05 in the project-level `build.gradle` file.
- Removed the `org.jetbrains.kotlin.android` plugin from both `build.gradle` files to use the built-in Kotlin support in AGP 9.0.
- Updated the `compileSdk` and `kotlinOptions` DSL in `app/build.gradle` to be compatible with AGP 9.0.
- Added the `foojay-resolver-convention` plugin to `settings.gradle` to handle Java toolchain resolution.

The build could not be verified in the environment due to a persistent error with the `gradlew` script. The project should be buildable in a local environment.