### PR TITLE
Fix: Correct Kotlin JVM target configuration for AGP 8.2.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,8 +26,8 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    kotlin {
-        jvmToolchain(8)
+    kotlinOptions {
+        jvmTarget = '1.8'
     }
 }
 


### PR DESCRIPTION
This commit fixes a build failure that occurred after downgrading to Gradle 8.2 and AGP 8.2.0.

The `kotlin` block in `app/build.gradle` is not supported in AGP 8.2.0. It has been replaced with the correct `kotlinOptions` block to set the Kotlin JVM target to 1.8, which is consistent with the project's Java version.